### PR TITLE
Add Event Types Registration Page

### DIFF
--- a/pages/event-types.js
+++ b/pages/event-types.js
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import styles from '../styles/home.module.css';
+
+export default function EventTypes() {
+  const [eventType, setEventType] = useState({
+    id: '',
+    name: ''
+  });
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log('Event Type submitted:', eventType);
+    // Here you would typically send the data to an API
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setEventType(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  return (
+    <div className={styles.container}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>
+          Cadastro de Tipos de Evento
+        </h1>
+
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.formGroup}>
+            <label htmlFor="id">ID:</label>
+            <input
+              type="text"
+              id="id"
+              name="id"
+              value={eventType.id}
+              onChange={handleChange}
+              className={styles.input}
+            />
+          </div>
+
+          <div className={styles.formGroup}>
+            <label htmlFor="name">Nome:</label>
+            <input
+              type="text"
+              id="name"
+              name="name"
+              value={eventType.name}
+              onChange={handleChange}
+              className={styles.input}
+            />
+          </div>
+
+          <button type="submit" className={styles.button}>
+            Cadastrar
+          </button>
+        </form>
+      </main>
+    </div>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import Button from '../components/Button'
 import ClickCount from '../components/ClickCount'
 import styles from '../styles/home.module.css'
+import Link from 'next/link'
 
 function throwError() {
   console.log(
@@ -28,12 +29,12 @@ function Home() {
 
   return (
     <main className={styles.main}>
-      <h1>Fast Refresh Demo</h1>
-      <p>
-        Fast Refresh is a Next.js feature that gives you instantaneous feedback
-        on edits made to your React components, without ever losing component
-        state.
-      </p>
+      <h1>Sistema de Eventos</h1>
+      <div style={{ marginBottom: '2rem' }}>
+        <Link href="/event-types" style={{ color: '#0070f3', textDecoration: 'none' }}>
+          Ir para Cadastro de Tipos de Evento →
+        </Link>
+      </div>
       <hr className={styles.hr} />
       <div>
         <p>

--- a/styles/home.module.css
+++ b/styles/home.module.css
@@ -9,3 +9,45 @@
   border-bottom: 1px solid #efefef;
   margin: 3em auto;
 }
+
+.title {
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.input {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.button {
+  padding: 0.75rem 1.5rem;
+  background-color: #0070f3;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.button:hover {
+  background-color: #0051b3;
+}


### PR DESCRIPTION
This PR adds a new page for registering Event Types with the following features:

- New `/event-types` page with a form containing ID and Name fields
- Styled form components with modern design
- Updated homepage with a link to the new page
- Form submission handling (currently logs to console)

The page allows users to input and manage event types in a user-friendly interface.